### PR TITLE
Crash Fix: Writing to obb folder crashes system

### DIFF
--- a/roms/10/Generic/make.sh
+++ b/roms/10/Generic/make.sh
@@ -1,3 +1,8 @@
 #/bin/bash
 
 # booooo
+
+systempath=$1
+thispath = `cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
+
+sed -i "/mkdir \/data\/media 0770 media_rw media_rw/a \ \ \ \ mkdir /data/media/obb 0770 media_rw media_rw" $1/init.rc 


### PR DESCRIPTION
"obb" folder is not created and it causes system to crash. This pr should fix that problem, but it is not tested.